### PR TITLE
Allow SU values for the _cell_measurement_wavelength data item

### DIFF
--- a/dictionaries/cif_core.dic
+++ b/dictionaries/cif_core.dic
@@ -16,8 +16,8 @@
 
 data_on_this_dictionary
     _dictionary_name            cif_core.dic
-    _dictionary_version         2.5.3-dev-8
-    _dictionary_update          2023-09-12
+    _dictionary_version         2.5.3-dev-9
+    _dictionary_update          2024-09-17
     _dictionary_history
 ;
    1991-05-27  Created from CIF Dictionary text. SRH
@@ -730,7 +730,7 @@ data_on_this_dictionary
    2018-03-05 AV: Maintenance update:
                   Added 'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 'Cn'
                   as enumerator values of the _diffrn_source_target data item.
-   2023-09-12 AV: Maintenance update:
+   2024-09-17 AV: Maintenance update:
                   Changed the value of the _list data item from 'yes' to 'both'
                     in the definitions of the _diffrn_radiation_wavelength_id,
                     _diffrn_radiation_wavelength_wt, _exptl_crystal_id,
@@ -762,6 +762,8 @@ data_on_this_dictionary
 
                   Updated example of the _chemical_identifier_inchi_key
                   data item.
+
+                  Added '_type_conditions su' to _cell_measurement_wavelength.
 ;
 
 ###############
@@ -2617,6 +2619,7 @@ data_cell_measurement_wavelength
     _name                      '_cell_measurement_wavelength'
     _category                    cell
     _type                        numb
+    _type_conditions             su
     _enumeration_range           0.0:
     _units                       A
     _units_detail                angstrom


### PR DESCRIPTION
This PR allows the `_cell_measurement_wavelength` data item to have associated standard uncertainty (SU) values as is done for other data items that record measurements (`_cell_measurement_temperature`, `_cell_measurement_pressure`, `_diffrn_radiation_wavelength`).